### PR TITLE
Fix custom date format

### DIFF
--- a/material-datepicker/js/material.datepicker.js
+++ b/material-datepicker/js/material.datepicker.js
@@ -63,7 +63,7 @@ $.fn.datepicker = function (options) {
 		format: "DD/MM/YYYY",
 		colour: "#009688"
 	};
-	var options = $.extend(options, defaults);
+	var options = $.extend(defaults, options);
 
 	function AppViewModel(field, picker, options) {
 		var self = this;

--- a/material-datepicker/js/material.datepicker.js
+++ b/material-datepicker/js/material.datepicker.js
@@ -113,7 +113,7 @@ $.fn.datepicker = function (options) {
 	    	self.monthStruct.removeAll();
 	    	var month = self.viewingMonth();
 	    	var year = self.viewingYear();
-	    	var startOfMonth = moment( "1/" + month + "/" + year, self.options.format).startOf('month');
+	    	var startOfMonth = moment(year + '-' + month + '-01').startOf('month');
 	    	var startDay = startOfMonth.format('dddd');
 	    	var startingPoint = startOfMonth.day();
 	    	var daysInMonth = startOfMonth.endOf('month').date();

--- a/material-datepicker/js/material.datepicker.js
+++ b/material-datepicker/js/material.datepicker.js
@@ -90,7 +90,7 @@ $.fn.datepicker = function (options) {
 
 		self.processDate = function(day) {
 			if (day) {
-				var date = moment( day + '/' + self.viewingMonth() + '/' + self.viewingYear(), self.options.format );
+				var date = moment(self.viewingYear() + '-' + self.viewingMonth() + '-' + day);
 				self.datePickerValue(date);
 				var year = self.viewingYear();
 				var month = self.viewingMonth();


### PR DESCRIPTION
The current implementation of a custom date format doesn't work. e.g. 

`
    var options = {
        format: "YYYY-MM-DD"
    };
    $('#inputfield').datepicker(options);
`

This PR fixes the problem.
