### PR TITLE
Remove Roboto Semibold

### DIFF
--- a/material-datepicker/css/material.datepicker.css
+++ b/material-datepicker/css/material.datepicker.css
@@ -11,12 +11,6 @@
 
 @font-face {
 	font-family: Roboto;
-	src: url('../fonts/Roboto-Semibold.ttf');
-	font-weight: 600;
-}
-
-@font-face {
-	font-family: Roboto;
 	src: url('../fonts/Roboto-Light.ttf');
 	font-weight: 300;
 }


### PR DESCRIPTION
Even though the CSS referenced it, there is no Roboto-Semibold.ttf in this project and from what I gather on the internet, that file doesn't exist. I couldn't find it anywhere. So I assume it's a mistake and this PR removes the reference.

Internet Explorer's debug console was posting an error about the missing file.
