### PR TITLE
Increase timeout to fix IE bug

### DIFF
--- a/material-datepicker/js/material.datepicker.js
+++ b/material-datepicker/js/material.datepicker.js
@@ -39,7 +39,7 @@ $.fn.datepicker = function (options) {
 			if (!picker.is(":focus")) {
 				picker.addClass('hide');
 			}
-		}, 10);
+		}, 200);
 
 	});
 
@@ -48,7 +48,7 @@ $.fn.datepicker = function (options) {
 			if (!($(field).is(":focus"))) {
 				picker.addClass('hide');
 			}
-		}, 10);
+		}, 200);
 	});
 
 	// setup picker position in relation to the field


### PR DESCRIPTION
With the low timeout values of 10ms, the click events never fire in IE. I had to increase the timeout values significantly for the click events to fire. The 200ms doesn't make a significant visual difference to me though.
